### PR TITLE
Updated [2024-03-16 2334H - 2338H] : merging Development to main

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -213,3 +213,8 @@
     - Updated main docker-compose file 'docker-comose.yaml'
         + Replaced mount directory '/root' to '${HOME}'
 
+#### 2334H
+- Updates
+    - Updated document 'README.md'
+        + Replaced tag/version 'latest' to the pseudovariable 'base-distributions' (to be replaced with the user's intended base distribution image)
+

--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -218,3 +218,8 @@
     - Updated document 'README.md'
         + Replaced tag/version 'latest' to the pseudovariable 'base-distributions' (to be replaced with the user's intended base distribution image)
 
+#### 2338H
+- Updates
+    - Updated document 'README.md'
+        + Added notes for the 'build' key-value in 'docker-compose.yaml'
+

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@
 - Design docker-compose.yaml file
     - Notes
         + You can find example docker-compose.yaml configuration files in the 'docker/compose' directory
+        - The 'build' instruction/key-value (dictionary) is optional if you have performed multi-staged builds as recommended previously
+            + You can use this if you are intending to use the base image directly
     ```yaml
     version: 3.7
     services:
@@ -157,6 +159,10 @@
                          .
             ```
     - Configure and Prepare your docker-compose.yaml file
+        - Notes
+            + You can find example docker-compose.yaml configuration files in the 'docker/compose' directory
+            - The 'build' instruction/key-value (dictionary) is optional if you have performed multi-staged builds as recommended previously
+                + You can use this if you are intending to use the base image directly
         ```yaml
         version: 3.7
         services:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 ### Using docker-compose
 - Build your base (stage 1) IDE docker image
     ```bash
-    docker build --tag=thanatisia/docker-ide:latest \
+    docker build --tag=thanatisia/docker-ide:[base-distribution] \
                  -f docker/Dockerfiles/[base-distribution]/programming-languages/[language].Dockerfile \
                  .
     ```
@@ -139,7 +139,7 @@
 - Using docker-compose environment
     - Build your base (stage 1) IDE docker image
         ```bash
-        docker build --tag=thanatisia/docker-ide:latest \
+        docker build --tag=thanatisia/docker-ide:[base-distribution] \
                      -f docker/Dockerfiles/[base-distribution]/programming-languages/[language].Dockerfile \
                      .
         ```
@@ -183,7 +183,7 @@
 - Using docker run
     - Build your base (stage 1) IDE docker image
         ```bash
-        docker build --tag=thanatisia/docker-ide:latest \
+        docker build --tag=thanatisia/docker-ide:[base-distribution] \
                      -f docker/Dockerfiles/[base-distribution]/programming-languages/[language].Dockerfile \
                      .
         ```
@@ -232,7 +232,7 @@
 - `STAGE_1_IMAGE_NAME` : Set the target name of the image to build
     + Default: thanatisia/docker-ide
 - `STAGE_1_IMAGE_TAG`  : Set the tag/version of the image to build
-    + Default: latest
+    + Default: `[base-distribution]`
 + `STAGE_1_BUILD_ARGS` : Specify the build arguments to parse into the build process
 - `STAGE_1_DOCKERFILE` : Specify the path to the custom Dockerfile to build
     + Default: 'docker/Dockerfiles/[base-distributions]/[language].Dockerfile'


### PR DESCRIPTION
#### 2334H
- Updates
    - Updated document 'README.md'
        + Replaced tag/version 'latest' to the pseudovariable 'base-distributions' (to be replaced with the user's intended base distribution image)

#### 2338H
- Updates
    - Updated document 'README.md'
        + Added notes for the 'build' key-value in 'docker-compose.yaml'